### PR TITLE
Support for UUID DB identifiers

### DIFF
--- a/src/groovy/org/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
+++ b/src/groovy/org/grails/plugins/elasticsearch/mapping/ElasticSearchMappingFactory.groovy
@@ -96,6 +96,8 @@ class ElasticSearchMappingFactory {
 
                     if (idTypeIsMongoObjectId(idType)) {
                         idType = treatValueAsAString(idType)
+                    } else if (idTypeIsUUID(idType)) {
+                        idType = 'string'
                     }
 
                     props.id = defaultDescriptor(idType, 'not_analyzed', true)
@@ -206,6 +208,10 @@ class ElasticSearchMappingFactory {
 
     private static boolean idTypeIsMongoObjectId(String idType) {
         idType.equals('objectId')
+    }
+
+    private static boolean idTypeIsUUID(String idType) {
+        idType.equalsIgnoreCase('uuid')
     }
 
     private static String treatValueAsAString(String idType) {


### PR DESCRIPTION
Similar to the logic for mongo objectId, this uses a String type when a DB is configured with UUIDs as identifiers.
